### PR TITLE
Upgrade nodejs to 12.16.1 LTS

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -52,7 +52,7 @@ RUN curl -sSLO "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANT
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 8.11.1
+ENV NODE_VERSION 12.16.1
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -52,7 +52,7 @@ RUN curl -sSLO "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANT
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 8.11.1
+ENV NODE_VERSION 12.16.1
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Docker Ruby images used by Gitlab CI.
 
 The following dependencies are being installed on all images:
 
-* Node.js v8.11.1 and npm
+* Node.js and npm
+  * v6.11.1 (9.1-jruby)
+  * v8.11.1 (2.1, 2.2, 2.3, 2.5)
+  * v12.16.1 (2.6, 2.7)
 * PhantomJS v2.1.1
 * Qt v5 and Xvbf (only on CRuby images)
 * Chrome Webdriver (latest stable)


### PR DESCRIPTION
This PR upgrades NodeJS to 12.16.1 LTS on newer images, and leaves older images as is, to not interfere with older projects.