### PR TITLE
Upgrade Node.js version

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.7
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.0
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.1
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.2
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.3
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.4
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Docker Ruby images used by Gitlab CI.
 
 The following dependencies are being installed on all images:
 
-* Node.js v18.17.1 (with npm)
+* Node.js v22.12.0 (with npm)
 * Google Chrome (latest stable)
 * Chrome Webdriver (version 131.0.6778.85)
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:latest
-MAINTAINER Codeminer42 <contact@codeminer42.com>
+LABEL org.opencontainers.image.authors="contact@codeminer42.com"
 
 # Add Google Chrome PPA
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -40,12 +40,11 @@ ENV CHROMEDRIVER_URL_BASE ''
 
 # Install node / npm
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 18.17.1
+ENV NODE_VERSION 22.12.0
 
 RUN curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 && \
-    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz" && \
-    npm install npm -g
+    rm -f "node-v$NODE_VERSION-linux-x64.tar.xz"
 
 # Encoding
 ENV LANG C.UTF-8


### PR DESCRIPTION
This PR upgrades Node.js to its [LTS](https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule) version and removes the command to install `npm`. Such a command is no longer needed since Node already comes with a compatible `npm`.